### PR TITLE
updated incorrect description of input object in universal-sentence-encoder

### DIFF
--- a/universal-sentence-encoder/README.md
+++ b/universal-sentence-encoder/README.md
@@ -94,10 +94,12 @@ use.loadQnA().then(model => {
   //   responses: Response[];
   // }
   // queries is an array of question strings
-  // responses is an array of following structure:
+  // To add context to support the answer,  context is also an Array of string corresponding to the answers.
+  // the input to the embed method would be
   // {
-  //   response: string;
-  //   context?: string;
+  //    queries:string[];
+  //    responses:string[];
+  //    context:string[];   
   // }
   // context is optional, it provides the context string of the answer.
 


### PR DESCRIPTION
Old readme described :
  // responses is an array of the following structure:
  // {
  //   response: string;
  //   context?: string;
  // }

The error obtained in running the code : 
universal-sentence-encoder:17 Uncaught (in promise) TypeError: e.normalize is not a function
    at universal-sentence-encoder:17
    at c.encode (universal-sentence-encoder:17)
    at universal-sentence-encoder:17
    at Array.map (<anonymous>)
    at j.tokenizeStrings (universal-sentence-encoder:17)
    at universal-sentence-encoder:17
    at tfjs:17
    at e.t.scopedRun (tfjs:17)
    at e.t.tidy (tfjs:17)
    at Object.bx [as tidy] (tfjs:17)

This error is  due to the **incorrect object definition of "input"**
On observation of  the code of universal-sentence-encoder, we see that  

```
embed(e) {
            const n = t.tidy(()=>{
                const t = this.tokenizeStrings(e.queries, f)
                  , n = this.tokenizeStrings(e.responses, f);
                if (null != e.contexts && e.contexts.length !== e.responses.length)
                    throw new Error("The length of response strings and context strings need to match.");
                const o = e.contexts || [];

```
So e.queries and e.contexts show that the input object should be

```
input =  
{
    queries: string[],
    responses: string[],
    contexts:string[]
}
```

So that i what I propose to be updated in the readme